### PR TITLE
CIV-891 Update k8s templates from idv-toolkit

### DIFF
--- a/deploy/kubernetes/idv/requirements.lock
+++ b/deploy/kubernetes/idv/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com
-  version: 4.4.0
+  version: 7.3.2
 - name: rabbitmq
   repository: https://kubernetes-charts.storage.googleapis.com
-  version: 4.2.0
-digest: sha256:30397e097e394b91ee11ad0cb31aee882907bf15c841548e64c4b5157abf3bb7
-generated: 2019-02-11T14:35:10.940511+01:00
+  version: 6.7.4
+digest: sha256:5351b6ce598a0ad627f728f64b18c379de2b83783e64f4fa6ad06579b1b7cfff
+generated: "2020-07-02T10:08:02.732092-03:00"

--- a/deploy/kubernetes/idv/requirements.yaml
+++ b/deploy/kubernetes/idv/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
   - name: mongodb
     repository: "@stable"
-    version: 4.4.x
+    version: 7.3.2
     condition: mongodb.internal
   - name: rabbitmq
     repository: "@stable"
-    version: 4.2.x
+    version: 6.7.4
     condition: rabbitmq.internal

--- a/deploy/kubernetes/idv/templates/ingress-no-path-rewrite.yaml
+++ b/deploy/kubernetes/idv/templates/ingress-no-path-rewrite.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-ingress-no-path-rewrite

--- a/deploy/kubernetes/idv/templates/interface-admin-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/interface-admin-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: admin-interface
+        requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
     spec:
       containers:
         - name: admin-interface
@@ -53,6 +54,8 @@ spec:
               value: {{.Values.admininterface.basePath}}{{ .Values.dataretentionmodule.basePath }}/*
             - name: ADMIN_INTERFACE_DATARETENTION_ENDPOINT
               value: http://{{ .Release.Name }}-data-retention-module:80
+            - name: NEW_RELIC_ENABLED
+              value: "false" #  "{{ .Values.newrelic.enabled }}"  # hard-code false for non-critical components to save NR costs
           ports:
             - name: http
               containerPort: 4050

--- a/deploy/kubernetes/idv/templates/interface-mobile-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/interface-mobile-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: mobile-interface
+        requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
     spec:
       containers:
         - name: mobile-interface
@@ -53,6 +54,8 @@ spec:
               value: {{ .Values.dataretentionmodule.basePath }}/*
             - name: MOBILE_INTERFACE_DATARETENTION_ENDPOINT
               value: http://{{ .Release.Name }}-data-retention-module:80
+            - name: NEW_RELIC_ENABLED
+              value: "{{ .Values.newrelic.enabled }}"
           ports:
             - name: http
               containerPort: 4000
@@ -66,6 +69,14 @@ spec:
         - name: config
           image: {{ .Values.pods.image.registry }}idvtoolkit/config:{{ .Values.pods.image.tag }}
           imagePullPolicy: {{ .Values.pods.imagePullPolicy }}
+          # PodPresets do not currently apply to InitContainers https://github.com/kubernetes/kubernetes/issues/55410
+          {{ if .Values.pods.labels.requiresAwsCreds }}
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: {{ .Values.aws_access_key_id }}
+            - name: AWS_SECRET_ACCESS_KEY
+              value: {{ .Values.aws_secret_access_key }}
+          {{ end }}
           volumeMounts:
             - mountPath: /resolvedConfig
               name: config

--- a/deploy/kubernetes/idv/templates/interface-notification-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/interface-notification-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: notification-interface
+        requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
     spec:
       containers:
         - name: notification-interface
@@ -25,6 +26,8 @@ spec:
               value: /opt/app/config/config/notificationinterface
             - name: NODE_ENV
               value: {{ .Values.pods.environment }}
+            - name: NEW_RELIC_ENABLED
+              value: "false" #  "{{ .Values.newrelic.enabled }}"  # hard-code false for non-critical components to save NR costs
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/kubernetes/idv/templates/middleware-analytics-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/middleware-analytics-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: analytics
+        requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
     spec:
       containers:
         - name: analytics
@@ -23,6 +24,10 @@ spec:
             # and populated by the idvtoolkit/config
             - name: NODE_CONFIG_DIR
               value: /opt/app/config/config/analytics
+            {{- if .Values.analytics.config }}
+            - name: NODE_CONFIG
+              value: {{ .Values.analytics.config | quote }}
+            {{- end}}
             # currently set to preprod only TODO move this to values.yaml
             - name: NODE_ENV
               value: {{ .Values.pods.environment }}
@@ -30,6 +35,8 @@ spec:
               {{- if .Values.rabbitmq.internal }}
               value: {{ .Release.Name }}-rabbitmq
               {{- end}}
+            - name: NEW_RELIC_ENABLED
+              value: "false" #  "{{ .Values.newrelic.enabled }}"  # hard-code false for non-critical components to save NR costs
             # force K8s to recreate the pod if the connection with RabbitMQ closes
             - name: EXIT_ON_CONNECTION_CLOSE
               value: "true"
@@ -47,6 +54,14 @@ spec:
         - name: config
           image: {{ .Values.pods.image.registry }}idvtoolkit/config:{{ .Values.pods.image.tag }}
           imagePullPolicy: {{ .Values.pods.imagePullPolicy }}
+          # PodPresets do not currently apply to InitContainers https://github.com/kubernetes/kubernetes/issues/55410
+          {{ if .Values.pods.labels.requiresAwsCreds }}
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: {{ .Values.aws_access_key_id }}
+            - name: AWS_SECRET_ACCESS_KEY
+              value: {{ .Values.aws_secret_access_key }}
+          {{ end }}
           volumeMounts:
             - mountPath: /resolvedConfig
               name: config

--- a/deploy/kubernetes/idv/templates/middleware-scheduler-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/middleware-scheduler-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: scheduler
+        requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
     spec:
       containers:
         - name: scheduler

--- a/deploy/kubernetes/idv/templates/module-attestation-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/module-attestation-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: attestation-module
+        requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
     spec:
       containers:
         - name: attestation-module
@@ -23,6 +24,10 @@ spec:
             # and populated by the idvtoolkit/config
             - name: NODE_CONFIG_DIR
               value: /opt/app/config/config/attestationmodule
+            {{- if .Values.attestationmodule.config }}
+            - name: NODE_CONFIG
+              value: {{ .Values.attestationmodule.config | quote }}
+            {{- end}}
             # currently set to preprod only TODO move this to values.yaml
             - name: NODE_ENV
               value: {{ .Values.pods.environment }}
@@ -31,6 +36,8 @@ spec:
               {{- if .Values.mongodb.internal }}
               value: {{ .Release.Name }}-mongodb
               {{- end}}
+            - name: NEW_RELIC_ENABLED
+              value: "{{ .Values.newrelic.enabled }}"
             - name: RABBITMQ_SERVICE
               {{- if .Values.rabbitmq.internal }}
               value: {{ .Release.Name }}-rabbitmq
@@ -64,6 +71,14 @@ spec:
         - name: config
           image: {{ .Values.pods.image.registry }}idvtoolkit/config:{{ .Values.pods.image.tag }}
           imagePullPolicy: {{ .Values.pods.imagePullPolicy }}
+          # PodPresets do not currently apply to InitContainers https://github.com/kubernetes/kubernetes/issues/55410
+          {{ if .Values.pods.labels.requiresAwsCreds }}
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: {{ .Values.aws_access_key_id }}
+            - name: AWS_SECRET_ACCESS_KEY
+              value: {{ .Values.aws_secret_access_key }}
+          {{ end }}
           volumeMounts:
             - mountPath: /resolvedConfig
               name: config

--- a/deploy/kubernetes/idv/templates/module-credential-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/module-credential-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: credential-module
+        requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
     spec:
       containers:
         - name: credential-module
@@ -23,9 +24,15 @@ spec:
             # and populated by the idvtoolkit/config
             - name: NODE_CONFIG_DIR
               value: /opt/app/config/config/credentialmodule
+            {{- if .Values.credentialmodule.config }}
+            - name: NODE_CONFIG
+              value: {{ .Values.credentialmodule.config | quote }}
+            {{- end}}
             # currently set to preprod only TODO move this to values.yaml
             - name: NODE_ENV
               value: {{ .Values.pods.environment }}
+            - name: NEW_RELIC_ENABLED
+              value: "{{ .Values.newrelic.enabled }}"
             # The DNS name for the db service. Should be available at mongodb://<db name>:27017
             - name: DB_SERVICE
               {{- if .Values.mongodb.internal }}
@@ -64,6 +71,14 @@ spec:
         - name: config
           image: {{ .Values.pods.image.registry }}idvtoolkit/config:{{ .Values.pods.image.tag }}
           imagePullPolicy: {{ .Values.pods.imagePullPolicy }}
+          # PodPresets do not currently apply to InitContainers https://github.com/kubernetes/kubernetes/issues/55410
+          {{ if .Values.pods.labels.requiresAwsCreds }}
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: {{ .Values.aws_access_key_id }}
+            - name: AWS_SECRET_ACCESS_KEY
+              value: {{ .Values.aws_secret_access_key }}
+          {{ end }}
           volumeMounts:
             - mountPath: /resolvedConfig
               name: config

--- a/deploy/kubernetes/idv/templates/module-data-retention-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/module-data-retention-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: data-retention-module
+        requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
     spec:
       containers:
         - name: data-retention-module
@@ -23,8 +24,15 @@ spec:
             # and populated by the idvtoolkit/config
             - name: NODE_CONFIG_DIR
               value: /opt/app/config/config/dataretentionmodule
+            {{- if .Values.dataretentionmodule.config }}
+            - name: NODE_CONFIG
+              value: {{ .Values.dataretentionmodule.config | quote }}
+            {{- end}}
+            # currently set to preprod only TODO move this to values.yaml
             - name: NODE_ENV
               value: {{ .Values.pods.environment }}
+            - name: NEW_RELIC_ENABLED
+              value: "false" #  "{{ .Values.newrelic.enabled }}"  # hard-code false for non-critical components to save NR costs
             - name: RABBITMQ_SERVICE
               {{- if .Values.rabbitmq.internal }}
               value: {{ .Release.Name }}-rabbitmq
@@ -58,6 +66,14 @@ spec:
         - name: config
           image: {{ .Values.pods.image.registry }}idvtoolkit/config:{{ .Values.pods.image.tag }}
           imagePullPolicy: {{ .Values.pods.imagePullPolicy }}
+          # PodPresets do not currently apply to InitContainers https://github.com/kubernetes/kubernetes/issues/55410
+          {{ if .Values.pods.labels.requiresAwsCreds }}
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: {{ .Values.aws_access_key_id }}
+            - name: AWS_SECRET_ACCESS_KEY
+              value: {{ .Values.aws_secret_access_key }}
+          {{ end }}
           volumeMounts:
             - mountPath: /resolvedConfig
               name: config

--- a/deploy/kubernetes/idv/templates/module-sign-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/module-sign-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: sign-module
+        requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
     spec:
       containers:
         - name: sign-module
@@ -23,9 +24,15 @@ spec:
             # and populated by the idvtoolkit/config
             - name: NODE_CONFIG_DIR
               value: /opt/app/config/config/signmodule
+            {{- if .Values.signmodule.config }}
+            - name: NODE_CONFIG
+              value: {{ .Values.signmodule.config | quote }}
+            {{- end}}
             # currently set to preprod only TODO move this to values.yaml
             - name: NODE_ENV
               value: {{ .Values.pods.environment }}
+            - name: NEW_RELIC_ENABLED
+              value: "{{ .Values.newrelic.enabled }}"
           ports:
             - name: http
               containerPort: 3030
@@ -51,6 +58,14 @@ spec:
         - name: config
           image: {{ .Values.pods.image.registry }}idvtoolkit/config:{{ .Values.pods.image.tag }}
           imagePullPolicy: {{ .Values.pods.imagePullPolicy }}
+          # PodPresets do not currently apply to InitContainers https://github.com/kubernetes/kubernetes/issues/55410
+          {{ if .Values.pods.labels.requiresAwsCreds }}
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: {{ .Values.aws_access_key_id }}
+            - name: AWS_SECRET_ACCESS_KEY
+              value: {{ .Values.aws_secret_access_key }}
+          {{ end }}
           volumeMounts:
             - mountPath: /resolvedConfig
               name: config

--- a/deploy/kubernetes/idv/templates/module-validation-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/module-validation-deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: validation-module
+        requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
     spec:
       containers:
         - name: validation-module
@@ -24,6 +25,10 @@ spec:
             # and populated by the idvtoolkit/config
             - name: NODE_CONFIG_DIR
               value: /opt/app/config/config/validationmodule
+            {{- if .Values.validationmodule.config }}
+            - name: NODE_CONFIG
+              value: {{ .Values.validationmodule.config | quote }}
+            {{- end}}
             - name: NODE_ENV
               value: {{ .Values.pods.environment }}
             # The DNS name for the db service. Should be available at mongodb://<db name>:27017
@@ -35,6 +40,8 @@ spec:
               {{- if .Values.rabbitmq.internal }}
               value: {{ .Release.Name }}-rabbitmq
               {{- end}}
+            - name: NEW_RELIC_ENABLED
+              value: "{{ .Values.newrelic.enabled }}"
           envFrom:
             - secretRef:
                   # these secrets are used to obtain the rabbitmq admin password
@@ -64,6 +71,14 @@ spec:
         - name: config
           image: {{ .Values.pods.image.registry }}idvtoolkit/config:{{ .Values.pods.image.tag }}
           imagePullPolicy: {{ .Values.pods.imagePullPolicy }}
+          # PodPresets do not currently apply to InitContainers https://github.com/kubernetes/kubernetes/issues/55410
+          {{ if .Values.pods.labels.requiresAwsCreds }}
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: {{ .Values.aws_access_key_id }}
+            - name: AWS_SECRET_ACCESS_KEY
+              value: {{ .Values.aws_secret_access_key }}
+          {{ end }}
           volumeMounts:
             - mountPath: /resolvedConfig
               name: config

--- a/deploy/kubernetes/idv/templates/module-validator-portal-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/module-validator-portal-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: validator-portal
+        requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
     spec:
       containers:
         - name: validator-portal
@@ -21,6 +22,10 @@ spec:
           env:
             - name: NODE_CONFIG_DIR
               value: /opt/app/config/config/validatorportal/backend
+            {{- if .Values.validatorportal.config }}
+            - name: NODE_CONFIG
+              value: {{ .Values.validatorportal.config | quote }}
+            {{- end}}
             - name: NODE_ENV
               value: {{ .Values.pods.environment }}
             - name: STAGE
@@ -38,6 +43,14 @@ spec:
         - name: config
           image: {{ .Values.pods.image.registry }}idvtoolkit/config:{{ .Values.pods.image.tag }}
           imagePullPolicy: {{ .Values.pods.imagePullPolicy }}
+          # PodPresets do not currently apply to InitContainers https://github.com/kubernetes/kubernetes/issues/55410
+          {{ if .Values.pods.labels.requiresAwsCreds }}
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: {{ .Values.aws_access_key_id }}
+            - name: AWS_SECRET_ACCESS_KEY
+              value: {{ .Values.aws_secret_access_key }}
+          {{ end }}
           volumeMounts:
             - mountPath: /resolvedConfig
               name: config

--- a/deploy/kubernetes/idv/values.yaml
+++ b/deploy/kubernetes/idv/values.yaml
@@ -6,6 +6,10 @@ pods:
   labels:
     requiresAwsCreds: false
 
+services:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+
 mongodb:
   internal: true
   usePassword: false
@@ -18,6 +22,8 @@ rabbitmq:
     requests:
       memory: 256Mi
       cpu: 100m
+  persistence:
+    enabled: false
 
 attestationmodule:
   basePath: /attestation
@@ -31,8 +37,15 @@ validationmodule:
 dataretentionmodule:
   basePath: /dataretention
 
+newrelic:
+  enabled: false
+
 admininterface:
   basePath: /admin
 
 notificationinterface:
   basePath: /notifications
+
+validatorportal: {}
+
+signmodule: {}


### PR DESCRIPTION
Update kubernetes templates from idv-toolkit:
- update mongodb dependency chart to version 7.3.2
- update rabbitmq dependency chart to version 6.7.4
- update apiVersion in the templates to be compatible with k8s 1.16
- add `requires-aws-creds` and `newrelic` configurations