### PR TITLE
CIV-52 Three helm fixes:

### DIFF
--- a/deploy/kubernetes/idv/templates/interface-admin-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/interface-admin-deployment.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app: admin-interface
         requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       containers:
         - name: admin-interface

--- a/deploy/kubernetes/idv/templates/interface-mobile-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/interface-mobile-deployment.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app: mobile-interface
         requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       containers:
         - name: mobile-interface

--- a/deploy/kubernetes/idv/templates/interface-notification-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/interface-notification-deployment.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app: notification-interface
         requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       containers:
         - name: notification-interface

--- a/deploy/kubernetes/idv/templates/middleware-analytics-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/middleware-analytics-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: analytics
         requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       containers:
         - name: analytics

--- a/deploy/kubernetes/idv/templates/middleware-scheduler-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/middleware-scheduler-deployment.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app: scheduler
         requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       containers:
         - name: scheduler

--- a/deploy/kubernetes/idv/templates/module-attestation-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/module-attestation-deployment.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app: attestation-module
         requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       containers:
         - name: attestation-module

--- a/deploy/kubernetes/idv/templates/module-credential-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/module-credential-deployment.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app: credential-module
         requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       containers:
         - name: credential-module

--- a/deploy/kubernetes/idv/templates/module-data-retention-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/module-data-retention-deployment.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app: data-retention-module
         requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       containers:
         - name: data-retention-module

--- a/deploy/kubernetes/idv/templates/module-sign-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/module-sign-deployment.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app: sign-module
         requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       containers:
         - name: sign-module

--- a/deploy/kubernetes/idv/templates/module-validator-portal-deployment.yaml
+++ b/deploy/kubernetes/idv/templates/module-validator-portal-deployment.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app: validator-portal
         requires-aws-creds: "{{ .Values.pods.labels.requiresAwsCreds }}"
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       containers:
         - name: validator-portal

--- a/deploy/kubernetes/idv/templates/rabbitmq-secrets.yaml
+++ b/deploy/kubernetes/idv/templates/rabbitmq-secrets.yaml
@@ -1,0 +1,20 @@
+# This secret file is copied from the rabbitmq subchart, and ensures that a
+# new secret is created for rabbitmq on install only. Subsequent updates
+# use the existing one.
+# For this to work, existingPasswordSecret and existingErlangSecret must be
+# true in values.yaml (to prevent the subchart from generating its own secret).
+{{ if or ( .Release.IsInstall ) (or (not .Values.rabbitmq.rabbitmq.existingErlangSecret) (not .Values.rabbitmq.rabbitmq.existingPasswordSecret)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.rabbitmq.fullnameOverride }}
+  labels:
+    app: {{ .Values.rabbitmq.fullnameOverride }}
+  annotations:
+    # prevents helmm from deleting this when Release.IsInstall is false
+    helm.sh/resource-policy: "keep"
+type: Opaque
+data:
+  rabbitmq-password: {{ randAlphaNum 10 | b64enc | quote }}
+  rabbitmq-erlang-cookie: {{ randAlphaNum 32 | b64enc | quote }}
+{{ end }}

--- a/deploy/kubernetes/idv/values.sample.yaml
+++ b/deploy/kubernetes/idv/values.sample.yaml
@@ -15,4 +15,4 @@ storage:
     zones: us-east-1a, us-east-1b
 
 analytics:
-  enabled: true
+  enabled: false

--- a/deploy/kubernetes/idv/values.yaml
+++ b/deploy/kubernetes/idv/values.yaml
@@ -23,6 +23,9 @@ mongodb:
 rabbitmq:
   fullnameOverride: rabbitmq
   internal: true
+  rabbitmq:
+    existingPasswordSecret: rabbitmq
+    existingErlangSecret: rabbitmq
   resources:
     requests:
       memory: 256Mi


### PR DESCRIPTION
1) A persistent rabbitmq secret that is not reset after every deploy (see https://github.com/bitnami/charts/issues/3094 )
2) Enable rolling pod deployments on upgrades
3) Disable analytics in the sample deployment